### PR TITLE
set up lo multicast in case wifi unavailable

### DIFF
--- a/services/mbot_start_networking.py
+++ b/services/mbot_start_networking.py
@@ -53,6 +53,10 @@ with open(log_file, "a") as log:
         f.write(hostname)
     log.write(f"hostname set to '{hostname}'\n")
 
+    # setup LO as multicast for localhost LCM connections
+    os.system("sudo ifconfig lo multicast")
+    os.system("sudo route add -net 224.0.0.0 netmask 240.0.0.0 dev lo")
+
     # Check if there is an active WiFi connection
     wifi_active = False
     wifi_status = os.popen("nmcli -t -f NAME,DEVICE,STATE c show --active").read().strip()


### PR DESCRIPTION
Added lines to mbot-start-networking.py so that lo multicast is always available for LCM in case wifi isn't available. This allows the robot to be run with full functionality from the webapp when connected to the robot's AP.