### PR TITLE
added autostart function

### DIFF
--- a/mbot_config.txt
+++ b/mbot_config.txt
@@ -5,4 +5,4 @@ new_wifi_password=HomeWifiPassword
 mbot_ip_list_url=https://github.com/MBot-Project-Development/mbot_ip_registry.git
 mbot_ip_list_user=mbotinfo
 mbot_ip_list_token=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
-autostart=run 
+autostart=run

--- a/mbot_config.txt
+++ b/mbot_config.txt
@@ -5,3 +5,4 @@ new_wifi_password=HomeWifiPassword
 mbot_ip_list_url=https://github.com/MBot-Project-Development/mbot_ip_registry.git
 mbot_ip_list_user=mbotinfo
 mbot_ip_list_token=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
+autostart=run 

--- a/services/install_mbot_services.sh
+++ b/services/install_mbot_services.sh
@@ -29,15 +29,15 @@ do
     # echo "Copying $serv"
 done
 
-fstab_entry="UUID=0009-C325       /media/mbot/RPI-RP2   auto           defaults                                     0 0"
-# Check if the line already exists in /etc/fstab
-if grep -qFx "$fstab_entry" /etc/fstab; then
-    echo "entry exists in /etc/fstab."
-else
-    # Append the line to /etc/fstab
-    echo "$fstab_entry" | sudo tee -a /etc/fstab
-    echo "entry added to /etc/fstab."
-fi
+# fstab_entry="UUID=0009-C325       /media/mbot/RPI-RP2   auto           defaults                                     0 0"
+# # Check if the line already exists in /etc/fstab
+# if grep -qFx "$fstab_entry" /etc/fstab; then
+#     echo "entry exists in /etc/fstab."
+# else
+#     # Append the line to /etc/fstab
+#     echo "$fstab_entry" | sudo tee -a /etc/fstab
+#     echo "entry added to /etc/fstab."
+# fi
 
 # Success message.
 echo

--- a/services/install_mbot_services.sh
+++ b/services/install_mbot_services.sh
@@ -29,6 +29,16 @@ do
     # echo "Copying $serv"
 done
 
+fstab_entry="UUID=0009-C325       /media/mbot/RPI-RP2   auto           defaults                                     0 0"
+# Check if the line already exists in /etc/fstab
+if grep -qFx "$fstab_entry" /etc/fstab; then
+    echo "entry exists in /etc/fstab."
+else
+    # Append the line to /etc/fstab
+    echo "$fstab_entry" | sudo tee -a /etc/fstab
+    echo "entry added to /etc/fstab."
+fi
+
 # Success message.
 echo
 echo "Installed and enabled the following services:"


### PR DESCRIPTION
When the robot boots up, the default value of autostart = run
mbot-start-network.service will set the RUN pin to low then BTLD pin to high then toggle the RUN to high, and the end, export the pins to free resource.